### PR TITLE
Update grandma2.js

### DIFF
--- a/grandma2.js
+++ b/grandma2.js
@@ -415,28 +415,28 @@ instance.prototype.action = function(action) {
 			cmd = `LUA 'gma.canbus.hardkey("${opt.relbutton}", false, false)'`;
 			break;
 		case 'encoder1':
-			cmd = `LUA 'gma.canbus.encoder(0, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(0, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder2':
-			cmd = `LUA 'gma.canbus.encoder(1, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(1, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder3':
-			cmd = `LUA 'gma.canbus.encoder(2, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(2, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder4':
-			cmd = `LUA 'gma.canbus.encoder(3, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(3, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder5':
-			cmd = `LUA 'gma.canbus.encoder(4, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(4, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder6':
-			cmd = `LUA 'gma.canbus.encoder(5, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(5, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder7':
-			cmd = `LUA 'gma.canbus.encoder(6, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(6, "${opt.encoder}", False)'`;
 			break;
 		case 'encoder8':
-			cmd = `LUA 'gma.canbus.encoder(7, "${opt.encoder}", false)'`;
+			cmd = `LUA 'gma.canbus.encoder(7, "${opt.encoder}", False)'`;
 			break;
 	}
 


### PR DESCRIPTION
updated the case-sensitive false statement for the encoder function,  its possible others are affected too, 

could you please double-check if these lines are affected as well, 

Line 411 - 416
		case 'pushbutton':
			cmd = `LUA 'gma.canbus.hardkey("${opt.pushbutton}", true, false)'`;
			break;
		case 'relbutton':
			cmd = `LUA 'gma.canbus.hardkey("${opt.relbutton}", false, false)'`;
			break;